### PR TITLE
FIX: properly propagate _run() method of procurement.order across the class hierarchy

### DIFF
--- a/purchase_request_to_requisition/models/procurement.py
+++ b/purchase_request_to_requisition/models/procurement.py
@@ -66,4 +66,6 @@ class Procurement(models.Model):
             req = request_obj.create(request_data)
             procurement.message_post(body=_("Purchase Request created"))
             procurement.request_id = req.id
-        return True
+            return True
+        return super(Procurement, self)._run(procurement)
+


### PR DESCRIPTION
This fixes a bug where delivery orders are not created from sales orders
