### PR TITLE
[FIX] fix error when create PO/Bid from PR line w/o product_id

### DIFF
--- a/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition.py
+++ b/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition.py
@@ -77,8 +77,6 @@ class PurchaseRequestLineMakePurchaseRequisition(models.TransientModel):
                  item.product_uom_id.id or False),
                 ('account_analytic_id', '=',
                  item.line_id.analytic_account_id.id or False)]
-        if not item.product_id:
-            vals['name'] = item.name
         return vals
 
     @api.multi

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -127,7 +127,9 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             'product_id': product.id,
             'account_analytic_id': item.line_id.analytic_account_id.id,
             'taxes_id': [(6, 0, vals.get('taxes_id', []))],
-            'purchase_request_lines': [(4, item.line_id.id)]
+            'purchase_request_lines': [(4, item.line_id.id)],
+            'date_planned':
+                vals.get('date_planned', False) or item.line_id.date_required,
         })
         return vals
 
@@ -140,7 +142,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
                            ('account_analytic_id', '=',
                             item.line_id.analytic_account_id.id or False)]
         if not item.product_id:
-            order_line_data['name'] = item.name
+            order_line_data.append(('name', '=', item.name))
         return order_line_data
 
     @api.multi


### PR DESCRIPTION
Create PO / Bid from Purchase Request line without product_id, error occurs because
- search domain not properly setup
- data_planned = Null

![098](https://cloud.githubusercontent.com/assets/1973598/13025585/799c8b58-d23d-11e5-87cf-a7d5a221a9d8.png)

![099](https://cloud.githubusercontent.com/assets/1973598/13025599/dce165ee-d23d-11e5-8688-cdf12e50c714.png)
