### PR TITLE
[FIX] purchase_request_to_rfq, assign date_planned if none.

### DIFF
--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -362,6 +362,7 @@
             <field name="res_model">purchase.request.line</field>
             <field name="view_type">form</field>
             <field name="view_mode">tree,form</field>
+            <field name="domain">[('request_state','!=','draft')]</field>
             <field name="search_view_id" ref="purchase_request_line_search"/>
         </record>
 

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -106,12 +106,15 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             fiscal_position_id=po.partner_id.property_account_position.id,
             date_planned=item.line_id.date_required,
             name=False, price_unit=False, state='draft')['value']
+        # If no product_id, date_planned won't be prepared, use today instead
         vals.update({
             'order_id': po.id,
             'product_id': product.id,
             'account_analytic_id': item.line_id.analytic_account_id.id,
             'taxes_id': [(6, 0, vals.get('taxes_id', []))],
             'purchase_request_lines': [(4, item.line_id.id)],
+            'date_planned': (vals.get('date_planned') or
+                             item.line_id.date_required)
         })
         if item.line_id.procurement_id:
             vals['procurement_ids'] = [(4, item.line_id.procurement_id.id)]


### PR DESCRIPTION
If no product_id, date_planned won't be prepare. But we need it or
error.
