### PR TITLE
[FIX] Error raised if no procurement during the creation of the purch…

### DIFF
--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -179,17 +179,14 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             line_location = line.procurement_id and \
                 line.procurement_id.location_id or False
 
-            if location is not False and line_location != location:
+            if location is not False and line_location != location and\
+                    line_location:
                 raise exceptions.Warning(
                     _('You have to select lines '
                       'from the same procurement location.'))
             else:
                 location = line_location
 
-            # TODO: Please review
-            # kittiu: Error will be raised if no location,
-            #         this occur if use purchse_request to create order
-            #         should we use location from picking type?
             if not location:
                 location = picking_type.default_location_dest_id
 


### PR DESCRIPTION
…ase order form the purchase request
@jbeficent could you confirm this modification? I think this is a good way to close issue with the warning in case where we have no procurement_id and multiple line selected into for the process `purchase request line to rfq` . (or maybe I missed something about the utility of this field)
